### PR TITLE
Finishing touches before namespace request

### DIFF
--- a/.ansible-lint_rules/ValidationHasMetadataRule.py
+++ b/.ansible-lint_rules/ValidationHasMetadataRule.py
@@ -54,13 +54,13 @@ class ValidationHasMetadataRule(AnsibleLintRule):
     how_to_add_classification = {
         'groups': (
             "To add a new validation group, please add it in the groups.yaml "
-            "file at the root of the tripleo-validations project."
+            "file at the root of the operators-validations project."
         )
     }
 
     def get_classifications(self, classification='groups'):
         """Returns a list classification names
-        defined for tripleo-validations in the '{classification}.yaml' file
+        defined for operators-validations in the '{classification}.yaml' file
         located in the base repo directory.
         """
         file_path = os.path.abspath(classification + '.yaml')
@@ -123,7 +123,7 @@ class ValidationHasMetadataRule(AnsibleLintRule):
 
         if file['type'] == 'playbook':
             if path.startswith("playbooks/") \
-               or "tripleo-validations/playbooks/" in path:
+               or "operators-validations/playbooks/" in path:
 
                 # *hosts* line check
                 hosts = data.get('hosts', None)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-# Ansible Collection - validations.operators_validations
+# Ansible Collection - validationsframework.operators_validations
 
 Documentation for the collection.

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -3,7 +3,7 @@
 # The namespace of the collection. This can be a company/brand/organization or product namespace under which all
 # content lives. May only contain alphanumeric lowercase characters and underscores. Namespaces cannot start with
 # underscores or numbers and cannot contain consecutive underscores
-namespace: validations
+namespace: validationsframework
 
 # The name of the collection. Has the same character restrictions as 'namespace'
 name: operators_validations

--- a/playbooks/pods_running.yaml
+++ b/playbooks/pods_running.yaml
@@ -12,4 +12,4 @@
       products:
         - kubernetes
   roles:
-    - validations.operators_validations.check_pods
+    - validationsframework.operators_validations.check_pods


### PR DESCRIPTION
References to placeholder namespaces were replaced with name of the new org. Remaining tripleo references were removed as well.

Signed-off-by: Jiri Podivin <jpodivin@redhat.com>