### PR TITLE
Resolving ansible-galaxy compliance issues

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -9,7 +9,7 @@ namespace: validationsframework
 name: operators_validations
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 1.0.0
+version: 0.1.1
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,0 +1,2 @@
+---
+requires_ansible: '>=2.11.0'  # Use '>= 2.9.10' instead, if needed

--- a/roles/check_pods/README.md
+++ b/roles/check_pods/README.md
@@ -3,7 +3,7 @@ check_pods
 
 Verify that pods are in requested state. By default "Running",
 but it is possible to override the state variable.
- 
+
 Requirements
 ------------
 
@@ -13,9 +13,7 @@ Role Variables
 --------------
 
 Variable `desired_state` is set to "Running" by default and can be overriden
-when the role is called. Variable `metadata` is a dictionary 
-containing machine readable information about the role and isn't used during
-runtime.
+when the role is called.
 
 Dependencies
 ------------

--- a/roles/check_pods/meta/main.yml
+++ b/roles/check_pods/meta/main.yml
@@ -1,0 +1,51 @@
+---
+galaxy_info:
+  role_name: check_pods
+  author: Jiri Podivin
+  description: |
+    Verify that pods are in requested state. By default "Running",
+    however overrides are possible.
+
+  company: Red Hat
+
+  license: BSD
+
+  min_ansible_version: '1.2'
+
+  # If this a Container Enabled role, provide the minimum Ansible Container version.
+  # min_ansible_container_version:
+
+  # Optionally specify the branch Galaxy will use when accessing the GitHub
+  # repo for this role. During role install, if no tags are available,
+  # Galaxy will use this branch. During import Galaxy will access files on
+  # this branch. If Travis integration is configured, only notifications for this
+  # branch will be accepted. Otherwise, in all cases, the repo's default branch
+  # (usually master) will be used.
+  # github_branch:
+
+  #
+  # platforms is a list of platforms, and each platform has a name and a list of versions.
+  #
+  # platforms:
+  # - name: Fedora
+  #   versions:
+  #   - all
+  #   - 25
+  # - name: SomePlatform
+  #   versions:
+  #   - all
+  #   - 1.0
+  #   - 7
+  #   - 99.99
+
+  galaxy_tags: []
+  # List tags for your role here, one per line. A tag is a keyword that describes
+  # and categorizes the role. Users find roles by searching for tags. Be sure to
+  # remove the '[]' above, if you add tags to this list.
+  #
+  # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
+  #       Maximum 20 tags per role.
+
+dependencies: []
+# List your role dependencies here, one per line. Be sure to remove the '[]' above,
+# if you add dependencies to this list.

--- a/roles/check_pods/variables/main.yaml
+++ b/roles/check_pods/variables/main.yaml
@@ -1,6 +1,0 @@
----
-metadata:
-  name: Check pods
-  description: |
-    Verify that pods are in requested state. By default "Running",
-    however overrides are possible.


### PR DESCRIPTION
Collection now has proper metadata directory and version number in `galaxy.yml`. chekc_pods role metadata were moved in compliant location, and role README.md was adjusted to better reflect nature of variables.

Signed-off-by: Jiri Podivin <jpodivin@redhat.com>